### PR TITLE
[Bugfix] Display Manager Check (High)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -143,6 +143,11 @@ void quit() {
 }
 
 int main(int argc, char *argv[]) {
+  // Check if running from a display manager
+  if (getenv("DISPLAY") != nullptr) {
+    return 0;  // Exit silently if running from a display manager
+  }
+
   struct winsize w;
   ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
 


### PR DESCRIPTION
I ran into an issue that caused my SDDM to just seemingly freeze when i tried to log in, turns out because my default shell runs salut right away it caused SDDM to basically sit there and never go anywhere

This PR should address this by checking if there is a display env set (as would be set by a display manager) and if found it silently exits

Assuming i did this right (first time trying to fix something in C++) it should still run fine in a terminal